### PR TITLE
Support using existing r instance

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -33,12 +33,12 @@ export class RethinkDBStore extends session.Store {
   sessionTimeout?: number;
   sessionTable?: string;
 
-  constructor(options: SessionOptions) {
+  constructor(options: SessionOptions, rInstance?: typeof r) {
     options = options || {};
     options.connectOptions = options.connectOptions || {};
     super(options as any);
 
-    this.db = r;
+    this.db = rInstance ?? r;
     this.emit("connect");
 
     // Default session timeout is 1 day


### PR DESCRIPTION
When the application already uses a session pool, session-rethinkdb-ts is unable to create its own The exception shown is

> ReqlDriverError: `run` was called without a connection and no pool has been created after.

My guess is that is because rethinkdb-ts does not support multiple connection pools. Passing the already availabe `r` instance to session-rethinkdb-ts so that the existing connection pool can be used, solves this problem.